### PR TITLE
Updated repo badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # FutureHouse Platform API Documentation
 
+[![GitHub](https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white)](https://github.com/Future-House/futurehouse-client-docs)
+[![PyPI version](https://badge.fury.io/py/futurehouse-client.svg)](https://badge.fury.io/py/futurehouse-client)
+![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)
+![PyPI Python Versions](https://img.shields.io/pypi/pyversions/futurehouse-client)
+
+<!-- [![tests](https://github.com/Future-House/futurehouse-client-docs/actions/workflows/lint-and-tests.yaml/badge.svg)](https://github.com/Future-House/futurehouse-client-docs) -->
+
 Documentation and tutorials for futurehouse-client, a client for interacting with endpoints of the FutureHouse platform.
 
 <!--TOC-->


### PR DESCRIPTION
Our public repos follow different badge patterns. It became more evident with the cookbook. 
Now that we are linking the platform documentation to the platform and plan to release it, the cookbook will see more traffic. This PR (together with similar ones on other repos) fixes it.